### PR TITLE
Pricing 섹션을 가격 문의 CTA로 전환

### DIFF
--- a/src/app/components/price.jsx
+++ b/src/app/components/price.jsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { useI18n } from "@/context/I18nProvider";
 
 export default function Pricing({ scrollToContact }) {
@@ -8,143 +7,16 @@ export default function Pricing({ scrollToContact }) {
             <div className="mx-auto max-w-screen-xl px-4 py-8 lg:px-6 lg:py-16">
                 <div className="mx-auto mb-8 max-w-screen-md text-center lg:mb-12">
                     <h1 className="title-font mb-4 text-2xl font-medium text-gray-100 sm:text-3xl">{t('pricing.title')}</h1>
-                    <p className="lg:w-2/3 mx-auto leading-relaxed text-gray-400">{t('pricing.desc')}</p>
                 </div>
-                <div className="space-y-8 sm:gap-4 lg:grid lg:grid-cols-3 lg:space-y-0 xl:gap-6">
-                    {/* Standard Plan */}
-                    <div className="flex h-full w-full flex-col rounded-2xl border-2 border-gray-700 bg-gradient-to-br from-gray-800 to-gray-900 p-8 text-center text-white shadow-xl transition-all duration-300 hover:border-cyan-500 hover:shadow-2xl hover:shadow-cyan-500/20 hover:-translate-y-2">
-                        <h3 className="mb-2 text-3xl font-bold text-white">Standard</h3>
-                        <p className="mb-6 text-sm font-light text-gray-400">
-                            Monthly Subscription
+                <div className="mx-auto max-w-3xl">
+                    <div className="rounded-2xl border-2 border-gray-700 bg-gradient-to-br from-gray-800 to-gray-900 p-10 text-center shadow-xl transition-all duration-300 hover:border-cyan-500 hover:shadow-2xl hover:shadow-cyan-500/20 sm:p-14">
+                        <h3 className="mb-4 text-2xl font-bold text-white sm:text-3xl">Flexible Pricing for Every Organization</h3>
+                        <p className="mx-auto mb-8 max-w-xl leading-relaxed text-gray-400">
+                            Our plans are tailored to your organization&apos;s size and goals. Get in touch and we&apos;ll put together the right plan for you.
                         </p>
-                        <div className="mb-8 flex flex-col items-center justify-center">
-                            <span className="text-4xl font-extrabold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">Custom Pricing</span>
-                            <span className="mt-2 text-sm text-gray-400">Tailored to your organization</span>
-                        </div>
-                        <ul role="list" className="mb-8 flex-grow space-y-4 text-left">
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Includes around <span className="font-semibold text-white">30 contents</span></span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Basic AI reports</span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Up to <span className="font-semibold text-white">2 admins / 20 users</span></span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Admin Web Tool</span>
-                            </li>
-                        </ul>
                         <button
                             onClick={scrollToContact}
-                            className="mt-auto inline-flex w-full items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-5 py-3 font-semibold text-white transition-all duration-300 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/30 focus:outline-none">
-                            Contact us for pricing
-                        </button>
-                    </div>
-
-                    {/* Professional Plan */}
-                    <div className="flex h-full w-full flex-col rounded-2xl border-2 border-cyan-500 bg-gradient-to-br from-gray-800 to-gray-900 p-8 text-center text-white shadow-2xl shadow-cyan-500/30 transition-all duration-300 hover:shadow-cyan-500/50 hover:-translate-y-2 relative">
-                        <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 bg-gradient-to-r from-cyan-500 to-blue-500 text-white px-4 py-1 rounded-full text-sm font-semibold">
-                            Popular
-                        </div>
-                        <h3 className="mb-2 text-3xl font-bold text-white">Professional</h3>
-                        <p className="mb-6 text-sm font-light text-gray-400">
-                            Monthly Subscription
-                        </p>
-                        <div className="mb-8 flex flex-col items-center justify-center">
-                            <span className="text-4xl font-extrabold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">Custom Pricing</span>
-                            <span className="mt-2 text-sm text-gray-400">Tailored to your organization</span>
-                        </div>
-                        <ul role="list" className="mb-8 flex-grow space-y-4 text-left">
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Includes around <span className="font-semibold text-white">110 contents</span></span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Detailed AI reports</span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Up to <span className="font-semibold text-white">5 admins / 50 users</span></span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-cyan-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Advanced analytics features</span>
-                            </li>
-                        </ul>
-                        <button
-                            onClick={scrollToContact}
-                            className="mt-auto inline-flex w-full items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-5 py-3 font-semibold text-white transition-all duration-300 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/30 focus:outline-none">
-                            Contact us for pricing
-                        </button>
-                    </div>
-
-                    {/* Enterprise Plan */}
-                    <div className="flex h-full w-full flex-col rounded-2xl border-2 border-gray-700 bg-gradient-to-br from-gray-800 to-gray-900 p-8 text-center text-white shadow-xl transition-all duration-300 hover:border-purple-500 hover:shadow-2xl hover:shadow-purple-500/20 hover:-translate-y-2">
-                        <h3 className="mb-2 text-3xl font-bold text-white">Enterprise</h3>
-                        <p className="mb-6 text-sm font-light text-gray-400">
-                            Monthly Subscription
-                        </p>
-                        <div className="mb-8 flex flex-col items-center justify-center">
-                            <span className="text-4xl font-extrabold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">Custom Pricing</span>
-                            <span className="mt-2 text-sm text-gray-400">Tailored to your organization</span>
-                        </div>
-                        <ul role="list" className="mb-8 flex-grow space-y-4 text-left">
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-purple-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">All Professional features</span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-purple-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">SSO (Single Sign-On)</span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-purple-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Enhanced security</span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-purple-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">Customization options</span>
-                            </li>
-                            <li className="flex items-start space-x-3">
-                                <svg className="h-6 w-6 flex-shrink-0 text-purple-400 mt-0.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"></path>
-                                </svg>
-                                <span className="text-gray-200">API integration</span>
-                            </li>
-                        </ul>
-                        <button
-                            onClick={scrollToContact}
-                            className="mt-auto inline-flex w-full items-center justify-center rounded-lg bg-gradient-to-r from-purple-500 to-pink-500 px-5 py-3 font-semibold text-white transition-all duration-300 hover:from-purple-400 hover:to-pink-400 hover:shadow-lg hover:shadow-purple-500/30 focus:outline-none">
+                            className="inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-8 py-3 text-lg font-semibold text-white transition-all duration-300 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/30 focus:outline-none">
                             Contact us for pricing
                         </button>
                     </div>

--- a/src/app/components/price.jsx
+++ b/src/app/components/price.jsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { useI18n } from "@/context/I18nProvider";
 
-export default function Pricing() {
+export default function Pricing({ scrollToContact }) {
     const { t } = useI18n();
     return (
         <section>
@@ -17,9 +17,9 @@ export default function Pricing() {
                         <p className="mb-6 text-sm font-light text-gray-400">
                             Monthly Subscription
                         </p>
-                        <div className="mb-8 flex items-baseline justify-center">
-                            <span className="mr-2 text-6xl font-extrabold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">$100</span>
-                            <span className="text-gray-400 text-lg">/month</span>
+                        <div className="mb-8 flex flex-col items-center justify-center">
+                            <span className="text-4xl font-extrabold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">Custom Pricing</span>
+                            <span className="mt-2 text-sm text-gray-400">Tailored to your organization</span>
                         </div>
                         <ul role="list" className="mb-8 flex-grow space-y-4 text-left">
                             <li className="flex items-start space-x-3">
@@ -47,6 +47,11 @@ export default function Pricing() {
                                 <span className="text-gray-200">Admin Web Tool</span>
                             </li>
                         </ul>
+                        <button
+                            onClick={scrollToContact}
+                            className="mt-auto inline-flex w-full items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-5 py-3 font-semibold text-white transition-all duration-300 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/30 focus:outline-none">
+                            Contact us for pricing
+                        </button>
                     </div>
 
                     {/* Professional Plan */}
@@ -58,9 +63,9 @@ export default function Pricing() {
                         <p className="mb-6 text-sm font-light text-gray-400">
                             Monthly Subscription
                         </p>
-                        <div className="mb-8 flex items-baseline justify-center">
-                            <span className="mr-2 text-6xl font-extrabold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">$300</span>
-                            <span className="text-gray-400 text-lg">/month</span>
+                        <div className="mb-8 flex flex-col items-center justify-center">
+                            <span className="text-4xl font-extrabold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">Custom Pricing</span>
+                            <span className="mt-2 text-sm text-gray-400">Tailored to your organization</span>
                         </div>
                         <ul role="list" className="mb-8 flex-grow space-y-4 text-left">
                             <li className="flex items-start space-x-3">
@@ -88,6 +93,11 @@ export default function Pricing() {
                                 <span className="text-gray-200">Advanced analytics features</span>
                             </li>
                         </ul>
+                        <button
+                            onClick={scrollToContact}
+                            className="mt-auto inline-flex w-full items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-5 py-3 font-semibold text-white transition-all duration-300 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/30 focus:outline-none">
+                            Contact us for pricing
+                        </button>
                     </div>
 
                     {/* Enterprise Plan */}
@@ -96,8 +106,9 @@ export default function Pricing() {
                         <p className="mb-6 text-sm font-light text-gray-400">
                             Monthly Subscription
                         </p>
-                        <div className="mb-8 flex items-baseline justify-center">
-                            <span className="text-5xl font-extrabold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">Custom</span>
+                        <div className="mb-8 flex flex-col items-center justify-center">
+                            <span className="text-4xl font-extrabold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">Custom Pricing</span>
+                            <span className="mt-2 text-sm text-gray-400">Tailored to your organization</span>
                         </div>
                         <ul role="list" className="mb-8 flex-grow space-y-4 text-left">
                             <li className="flex items-start space-x-3">
@@ -131,6 +142,11 @@ export default function Pricing() {
                                 <span className="text-gray-200">API integration</span>
                             </li>
                         </ul>
+                        <button
+                            onClick={scrollToContact}
+                            className="mt-auto inline-flex w-full items-center justify-center rounded-lg bg-gradient-to-r from-purple-500 to-pink-500 px-5 py-3 font-semibold text-white transition-all duration-300 hover:from-purple-400 hover:to-pink-400 hover:shadow-lg hover:shadow-purple-500/30 focus:outline-none">
+                            Contact us for pricing
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -59,7 +59,7 @@ export default function Home() {
     <Features/>
     <Events/>
     {/* <Imageslider/> */}
-    {/* <Pricing/> */}
+    <Pricing scrollToContact={scrollToContact} />
     <Testimonials/>
     <Faq/>
     {/* FOOTER */}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -59,7 +59,7 @@ export default function Home() {
     <Features/>
     <Events/>
     {/* <Imageslider/> */}
-    <Pricing/>
+    {/* <Pricing/> */}
     <Testimonials/>
     <Faq/>
     {/* FOOTER */}


### PR DESCRIPTION
## Summary
- 가격 정책이 아직 확정되지 않아, 구체 금액/플랜 노출을 제거하고 가격 문의(Contact) 중심으로 전환
- 기존 3개 플랜 카드($100 / $300 / Custom + 기능 목록)를 단일 중앙 정렬 "가격 문의" CTA 배너로 교체
- "Contact us for pricing" 버튼은 기존 `scrollToContact` 패턴을 재사용해 하단 Contact 폼으로 부드럽게 스크롤
- 다크 그라데이션 테마/시안 액센트에 맞춘 디자인, 텍스트는 영어 사용

## Test plan
- [ ] 메인 페이지에서 Pricing 섹션이 단일 CTA 배너로 렌더되는지 확인
- [ ] "Contact us for pricing" 클릭 시 Contact 폼으로 스크롤되는지 확인
- [ ] 데스크톱/모바일 반응형 레이아웃 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01QwTRxo7wHT4Q5bouAyqPsD)_