### PR TITLE
fix(pricing): 데스크탑에서 CTA 박스 너비 정렬

### DIFF
--- a/src/app/components/price.jsx
+++ b/src/app/components/price.jsx
@@ -8,18 +8,16 @@ export default function Pricing({ scrollToContact }) {
                 <div className="mx-auto mb-8 max-w-screen-md text-center lg:mb-12">
                     <h1 className="title-font mb-4 text-2xl font-medium text-gray-100 sm:text-3xl">{t('pricing.title')}</h1>
                 </div>
-                <div className="mx-auto max-w-3xl">
-                    <div className="rounded-2xl border-2 border-gray-700 bg-gradient-to-br from-gray-800 to-gray-900 p-10 text-center shadow-xl transition-all duration-300 hover:border-cyan-500 hover:shadow-2xl hover:shadow-cyan-500/20 sm:p-14">
-                        <h3 className="mb-4 text-2xl font-bold text-white sm:text-3xl">Flexible Pricing for Every Organization</h3>
-                        <p className="mx-auto mb-8 max-w-xl leading-relaxed text-gray-400">
-                            Our plans are tailored to your organization&apos;s size and goals. Get in touch and we&apos;ll put together the right plan for you.
-                        </p>
-                        <button
-                            onClick={scrollToContact}
-                            className="inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-8 py-3 text-lg font-semibold text-white transition-all duration-300 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/30 focus:outline-none">
-                            Contact us for pricing
-                        </button>
-                    </div>
+                <div className="rounded-2xl border-2 border-gray-700 bg-gradient-to-br from-gray-800 to-gray-900 p-10 text-center shadow-xl transition-all duration-300 hover:border-cyan-500 hover:shadow-2xl hover:shadow-cyan-500/20 sm:p-14 lg:p-16">
+                    <h3 className="mb-4 text-2xl font-bold text-white sm:text-3xl">Flexible Pricing for Every Organization</h3>
+                    <p className="mx-auto mb-8 max-w-xl leading-relaxed text-gray-400">
+                        Our plans are tailored to your organization&apos;s size and goals. Get in touch and we&apos;ll put together the right plan for you.
+                    </p>
+                    <button
+                        onClick={scrollToContact}
+                        className="inline-flex items-center justify-center rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-8 py-3 text-lg font-semibold text-white transition-all duration-300 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/30 focus:outline-none">
+                        Contact us for pricing
+                    </button>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
데스크탑에서 Pricing CTA 박스가 위(갤러리)·아래(후기) 섹션보다 좁게 보이던 문제 수정.

- 배너 래퍼의 `max-w-3xl`(768px) 제한 제거 → 섹션 컨테이너 전체 너비로 정렬
- 데스크탑 비율 보강용 `lg:p-16` 패딩 추가, 본문은 `max-w-xl`로 가독성 유지
- 모바일 레이아웃은 변동 없음 (`max-w-3xl`은 모바일에 적용되지 않았음)

## Test plan
- [x] 데스크탑(1440px): 박스가 갤러리/후기와 동일 너비로 정렬됨 확인
- [x] 모바일(390px): 기존 레이아웃 유지 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01QwTRxo7wHT4Q5bouAyqPsD)_