### PR TITLE
fix(pricing): 대형 화면에서 CTA 박스 너비 정렬 (container 통일)

### DIFF
--- a/src/app/components/price.jsx
+++ b/src/app/components/price.jsx
@@ -4,7 +4,7 @@ export default function Pricing({ scrollToContact }) {
     const { t } = useI18n();
     return (
         <section>
-            <div className="mx-auto max-w-screen-xl px-4 py-8 lg:px-6 lg:py-16">
+            <div className="container mx-auto px-5 py-8 lg:py-16">
                 <div className="mx-auto mb-8 max-w-screen-md text-center lg:mb-12">
                     <h1 className="title-font mb-4 text-2xl font-medium text-gray-100 sm:text-3xl">{t('pricing.title')}</h1>
                 </div>


### PR DESCRIPTION
## Summary
1536px 이상 큰 화면에서 Pricing CTA 박스가 다른 섹션보다 좁게 보이던 문제 수정.

- **원인**: Pricing은 `max-w-screen-xl`(1280px), testimonials·events·contents는 Tailwind `container`(2xl=1536px)를 사용 → 1536px+ 화면에서 Pricing만 좁음
- **수정**: Pricing 컨테이너를 동일한 `container mx-auto px-5`로 통일

## Test plan
- [x] 1920px: Pricing 박스 너비(1496px)가 후기 카드 영역(1496px) 및 갤러리와 정렬됨 확인
- [x] 1440px / 모바일: 기존 레이아웃 유지


---
_Generated by [Claude Code](https://claude.ai/code/session_01QwTRxo7wHT4Q5bouAyqPsD)_